### PR TITLE
[DRAFT] Android: Prioritise detection of mobile over n/w

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/android/src/main/java/dev/fluttercommunity/plus/connectivity/Connectivity.java
+++ b/packages/connectivity_plus/connectivity_plus/android/src/main/java/dev/fluttercommunity/plus/connectivity/Connectivity.java
@@ -36,11 +36,11 @@ public class Connectivity {
       if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)) {
         return CONNECTIVITY_ETHERNET;
       }
-      if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) {
-        return CONNECTIVITY_VPN;
-      }
       if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) {
         return CONNECTIVITY_MOBILE;
+      }
+      if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) {
+        return CONNECTIVITY_VPN;
       }
       if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH)) {
         return CONNECTIVITY_BLUETOOTH;


### PR DESCRIPTION
Issue: When VPN is enabled over mobile network, app is uploading data even if users have turned off upload over mobile n/w. [Link](https://github.com/ente-io/photos-app/issues/1197)

Until https://github.com/fluttercommunity/plus_plugins/issues/1472 is resolved (by either new API or breaking changes), use this forked version. 

